### PR TITLE
Relisten crashes if a song has an empty string for its sortName

### DIFF
--- a/Shared/Extensions/String.swift
+++ b/Shared/Extensions/String.swift
@@ -27,5 +27,22 @@ extension String {
             return NSAttributedString()
         }
     }
+    
+    /// Returns a string suitable for grouping by in a table view
+    func groupNameForTableView() -> String {
+        if self.count == 0 {
+            return ""
+        }
+        var s = self[..<self.index(self.startIndex, offsetBy: 1)].uppercased()
+        
+        for ch in s.unicodeScalars {
+            if CharacterSet.decimalDigits.contains(ch) {
+                s = "#"
+                break
+            }
+        }
+        
+        return s
+    }
 }
 

--- a/Shared/View Controllers/Songs/SongsViewController.swift
+++ b/Shared/View Controllers/Songs/SongsViewController.swift
@@ -47,21 +47,9 @@ class SongsViewController: RelistenTableViewController<[SongWithShowCount]> {
     var groups: [Grouping<String, SongWithShowCount>]? = nil
     
     override func render(forData: [SongWithShowCount]) {
-        let digitSet = CharacterSet.decimalDigits
-        
         groups = sinq(forData)
             .groupBy({
-                let n = $0.sortName
-                var s = n[..<n.index(n.startIndex, offsetBy: 1)].uppercased()
-
-                for ch in s.unicodeScalars {
-                    if digitSet.contains(ch) {
-                        s = "#"
-                        break
-                    }
-                }
-                
-                return s
+                return $0.sortName.groupNameForTableView()
             })
             .toArray()
             .sorted(by: { (a, b) -> Bool in

--- a/Shared/View Controllers/Venues/VenuesViewController.swift
+++ b/Shared/View Controllers/Venues/VenuesViewController.swift
@@ -43,21 +43,9 @@ class VenuesViewController: RelistenTableViewController<[VenueWithShowCount]> {
     var groups: [Grouping<String, VenueWithShowCount>]? = nil
     
     override func render(forData: [VenueWithShowCount]) {
-        let digitSet = CharacterSet.decimalDigits
-        
         groups = sinq(forData)
             .groupBy({
-                let n = $0.sortName
-                var s = n[..<n.index(n.startIndex, offsetBy: 1)].uppercased()
-                
-                for ch in s.unicodeScalars {
-                    if digitSet.contains(ch) {
-                        s = "#"
-                        break
-                    }
-                }
-                
-                return s
+                return $0.sortName.groupNameForTableView()
             })
             .toArray()
             .sorted(by: { (a, b) -> Bool in


### PR DESCRIPTION
When looking at the list of songs for Widespread Panic I hit a crash because one of the songs (`id 1846`) has an empty string for its `name` and `sortName`