### PR TITLE
Jump right to the show view when tapping on an offline or recently played track

### DIFF
--- a/Apps/Relisten/View Controllers/ArtistsViewController.swift
+++ b/Apps/Relisten/View Controllers/ArtistsViewController.swift
@@ -230,7 +230,7 @@ class ArtistsViewController: RelistenAsyncTableController<[ArtistWithCounts]>, A
         
         if let s = show {
             let sourcesController = SourcesViewController(artist: s.artist, show: s.show)
-            sourcesController.presentIfNecessary(navigationController: navigationController)
+            sourcesController.presentIfNecessary(navigationController: navigationController, forSource: s.source)
         }
     }
 }

--- a/Shared/View Controllers/Show/SourcesViewController.swift
+++ b/Shared/View Controllers/Show/SourcesViewController.swift
@@ -21,6 +21,7 @@ class SourcesViewController: RelistenAsyncTableController<ShowWithSources> {
     let isRandom: Bool
     
     var sources: [SourceFull] = []
+    var sourceToPresent : SourceFull?
     var canSkipIfSingleSource : Bool
     
     public required init(artist: ArtistWithCounts, show: Show) {
@@ -49,12 +50,15 @@ class SourcesViewController: RelistenAsyncTableController<ShowWithSources> {
         fatalError()
     }
     
-    func presentIfNecessary(navigationController : UINavigationController?) {
+    func presentIfNecessary(navigationController : UINavigationController?, forSource source: SourceFull? = nil) {
         self.load()
         var controllerToPresent : UIViewController = self
-        if self.sources.count == 1 {
-            if let show = latestData {
+        sourceToPresent = source
+        if let show = latestData {
+            if self.sources.count == 1 {
                 controllerToPresent = SourceViewController(artist: artist, show: show, source: sources[0])
+            } else if let source = source {
+                controllerToPresent = SourceViewController(artist: artist, show: show, source: source)
             }
         }
         navigationController?.pushViewController(controllerToPresent, animated: true)
@@ -86,8 +90,14 @@ class SourcesViewController: RelistenAsyncTableController<ShowWithSources> {
         
         sources = data.sources
         if canSkipIfSingleSource {
+            var controllerToPresent : SourceViewController?
             if sources.count == 1 {
-                let controllerToPresent = SourceViewController(artist: artist, show: data, source: sources[0])
+                controllerToPresent = SourceViewController(artist: artist, show: data, source: sources[0])
+            } else if let source = sourceToPresent {
+                controllerToPresent = SourceViewController(artist: artist, show: data, source: source)
+            }
+            
+            if let controllerToPresent = controllerToPresent {
                 if var viewControllers = navigationController?.viewControllers {
                     if viewControllers.last == self {
                         viewControllers.removeLast()


### PR DESCRIPTION
If a track is saved offline then the user already selected a source, so don't show them a source when they tap on that track again- jump right to the source and present the show.