### PR TITLE
I hit a crash on my phone when the recently played tracks list was updated

### DIFF
--- a/Apps/Relisten/View Controllers/ArtistsViewController.swift
+++ b/Apps/Relisten/View Controllers/ArtistsViewController.swift
@@ -113,12 +113,13 @@ class ArtistsViewController: RelistenAsyncTableController<[ArtistWithCounts]>, A
     }
     
     private func reloadRecentShows(tracks: [Track]) {
+        let recentShows = self.recentlyPlayedTracks.map({ ($0.showInfo.show, $0.showInfo.artist) }) as [(show: Show, artist: ArtistWithCounts?)]
+        
         DispatchQueue.main.async {
             self.recentlyPlayedTracks = tracks
-            self.recentShowsNode.shows = self.recentlyPlayedTracks.map({ ($0.showInfo.show, $0.showInfo.artist) })
+            self.recentShowsNode.shows = recentShows
             self.tableNode.reloadSections([ Sections.recentlyPlayed.rawValue ], with: .automatic)
         }
-        recentShowsNode.shows = recentlyPlayedTracks.map({ ($0.showInfo.show, $0.showInfo.artist) })
     }
     
     // MARK: UITableViewDataSource


### PR DESCRIPTION
Luckily I was attached in the debugger, so I was able to poke at this and it looks like the problem is that `recentShowsNode.shows` was being set from one thread while the didSet handler was still running on the main thread.

I'm not 100% confident I got to the bottom of this crasher, but this fix at least makes things more efficient because the value isn't set twice 😉