### PR TITLE
Reload the favorites section after the first favorite is added

### DIFF
--- a/Apps/Relisten/View Controllers/ArtistsViewController.swift
+++ b/Apps/Relisten/View Controllers/ArtistsViewController.swift
@@ -66,7 +66,9 @@ class ArtistsViewController: RelistenAsyncTableController<[ArtistWithCounts]>, A
         library.favorites.artists.observeWithValue { [weak self] artists, changes in
             guard let s = self else { return }
 
+            let previousFavoriteCount = s.favoriteArtists.count
             s.favoriteArtists = Array(artists.map({ UUID(uuidString: $0.artist_uuid)! }))
+            let newFavoriteCount = s.favoriteArtists.count
 
             switch changes {
             case .initial:
@@ -79,6 +81,10 @@ class ArtistsViewController: RelistenAsyncTableController<[ArtistWithCounts]>, A
                                            with: .automatic)
                     s.tableNode.reloadRows(at: modifications.map({ IndexPath(row: $0, section: Sections.favorited.rawValue) }),
                                            with: .automatic)
+                    
+                    if previousFavoriteCount == 0, newFavoriteCount > 0 {
+                        s.tableNode.reloadSections(IndexSet(integer: Sections.favorited.rawValue), with: .automatic)
+                    }
                 }, completion: nil)
             case .error(let error):
                 fatalError(error.localizedDescription)


### PR DESCRIPTION
I launched a fresh copy of Relisten and added my first favorite and the section header for Favorites showed up half under the navigation title area:

![simulator screen shot - simulator x - 2018-08-08 at 20 31 37](https://user-images.githubusercontent.com/4943/43876591-a7409800-9b4a-11e8-83c0-7acc4d88e823.png)

It looks like the section needs to be reloaded when it first appears due to a row being added to it.