### PR TITLE
Apply the PhishOD colors when viewing a source

### DIFF
--- a/Shared/View Controllers/Show/SourceViewController.swift
+++ b/Shared/View Controllers/Show/SourceViewController.swift
@@ -49,8 +49,15 @@ public class SourceViewController: RelistenBaseAsyncTableViewController {
     public required init?(coder aDecoder: NSCoder) {
         fatalError()
     }
-
+    
     public override func viewDidLoad() {
+        if artist.name == "Phish" {
+            AppColors_SwitchToPhishOD(navigationController)
+        }
+        else {
+            AppColors_SwitchToRelisten(navigationController)
+        }
+        
         super.viewDidLoad()
         
         if show.sources.count == 1 {


### PR DESCRIPTION
This applies the PhishOD colors when viewing a Phish source from the main Relisten screen via a recent/favorite show cell. 