### PR TITLE
Show an "all sources" navigation item when viewing an individual show

### DIFF
--- a/Shared/View Controllers/Show/SourceViewController.swift
+++ b/Shared/View Controllers/Show/SourceViewController.swift
@@ -58,6 +58,18 @@ public class SourceViewController: RelistenBaseAsyncTableViewController {
         } else {
             title = "\(show.display_date) #\(idx + 1)"
         }
+        
+        if show.sources.count > 1 {
+            if let navigationController = navigationController,
+               !(navigationController.viewControllers[navigationController.viewControllers.count - 2] is SourcesViewController) {
+                let sourcesItem = UIBarButtonItem(title: "All Sources", style: .plain, target: self, action: #selector(sourcesNavItemTapped(_:)))
+                self.navigationItem.rightBarButtonItem = sourcesItem
+            }
+        }
+    }
+    
+    @objc public func sourcesNavItemTapped(_ sender: UINavigationBar?) {
+        navigationController?.pushViewController(SourcesViewController(artist: artist, show: show), animated: true)
     }
     
     // MARK: UITableViewDelegate


### PR DESCRIPTION
While writing the importer for the old version of Relisten I realized that some people may have previously favorited an entire show (since that's all that the old version could do) but the new version requires favoriting a single source. 

The importer has to pick a source, and it does this by just picking the source with the best rating.

This change adds a new navigation item when viewing a source directly (which happens via favorites/recents/etc) that lets the user jump to the list of sources for a show.