### PR TITLE
Remove Realm assertions for downloading files

### DIFF
--- a/Shared/Offline/MyLibrary.swift
+++ b/Shared/Offline/MyLibrary.swift
@@ -289,9 +289,6 @@ extension MyLibrary : DownloadManagerDataSource {
                 offlineTrack.state = .downloading
             }
         }
-        else {
-            assertionFailure("!!! ERROR: track began downloading BEFORE BEING STORED IN REALM !!!")
-        }
     }
     
     public func offlineTrackFailedDownloading(_ track: Track, error: Error?) {
@@ -334,13 +331,10 @@ extension MyLibrary : DownloadManagerDataSource {
                 offlineTrack.state = .downloaded
                 offlineTrack.file_size.value = Int(fileSize)
             }
+            
+            // add the source information if it doesn't exist
+            addOfflineSourceInfoForDownloadedTrack(track)
         }
-        else {
-            assertionFailure("!!! ERROR: track finished downloading BEFORE BEING STORED IN REALM !!!")
-        }
-        
-        // add the source information if it doesn't exist
-        addOfflineSourceInfoForDownloadedTrack(track)
     }
     
     public func offlineTrackWillBeDeleted(_ track: Track) {


### PR DESCRIPTION
These assertions can get tripped in legitimate cases if a file is deleted while a download is in progress, or a download is cancelled by the user right before it completes.

An attempt at fixing #76 