### PR TITLE
Fix the go to show button

### DIFF
--- a/Shared/Events/TrackActions.swift
+++ b/Shared/Events/TrackActions.swift
@@ -41,7 +41,7 @@ public class TrackActions {
         }))
         
         a.addAction(UIAlertAction(title: "Go to Show", style: .default, handler: { _ in
-            vc.navigationController?.pushViewController(SourcesViewController(artist: track.showInfo.artist, show: track.showInfo.show), animated: true)
+            SourcesViewController(artist: track.showInfo.artist, show: track.showInfo.show).presentIfNecessary(navigationController: RelistenApp.sharedApp.delegate.rootNavigationController)
         }))
 
         MyLibrary.shared.diskUsageForTrackURL(track: track.sourceTrack) { (size) in


### PR DESCRIPTION
`vc` is usually `AGAudioPlayerViewController`, which doesn't have a navigation controller. Let's just use the shared one from `RelistenApp`