### PR TITLE
Show listening history in the track list

### DIFF
--- a/Relisten.xcodeproj/project.pbxproj
+++ b/Relisten.xcodeproj/project.pbxproj
@@ -653,6 +653,7 @@
 				4330E72B211E0CA200329ED7 /* DownloadProgressNode.swift */,
 				43A035D0210D255700C087DD /* FavoriteButtonNode.swift */,
 				7C31553620C2079200F07622 /* HorizontalShowCollectionCellNode.swift */,
+				7C11B270214719C100D9D78D /* LinkUpstreamNode.swift */,
 				7C31552D20C2072D00F07622 /* OfflineIndicatorNode.swift */,
 				7C31552120BFC55900F07622 /* ReviewLayout.swift */,
 				7C31552720C0A08300F07622 /* ShareCellLayout.swift */,
@@ -668,7 +669,6 @@
 				43A035CF210D255700C087DD /* UserPropertiesForShowNode.swift */,
 				7CA3CD161F71766E00E936AB /* VenueLayout.swift */,
 				7C31553920C2081A00F07622 /* YearNode.swift */,
-				7C11B270214719C100D9D78D /* LinkUpstreamNode.swift */,
 			);
 			name = DisplayNodes;
 			sourceTree = "<group>";

--- a/Shared/Layouts/TrackStatusCellNode.swift
+++ b/Shared/Layouts/TrackStatusCellNode.swift
@@ -24,7 +24,8 @@ public class TrackStatusCellNode : ASCellNode {
     
     var disposal = Disposal()
     
-    var trackQuery: Results<OfflineTrack>!
+    var offlineTrackQuery: Results<OfflineTrack>!
+    var listenedTrackQuery: Results<RecentlyPlayedTrack>!
     
     public init(withTrack track: Track, withHandler handler: TrackStatusActionHandler, usingExplicitTrackNumber: Int? = nil, showingArtistInformation: Bool = false) {
         self.track = track
@@ -39,7 +40,10 @@ public class TrackStatusCellNode : ASCellNode {
         })
         nowPlayingNode.backgroundColor = UIColor.clear
         
-        trackNumberNode = ASTextNode(String(explicitTrackNumber ?? track.track_position), textStyle: .caption1, color: .darkGray)
+        if let _ = MyLibrary.shared.recent.tracks.filter("track_uuid == %@ AND past_halfway == true", self.track.uuid.uuidString).first {
+            hasListened = true
+        }
+        trackNumberNode = ASTextNode(String(explicitTrackNumber ?? track.track_position), textStyle: .caption1, color: hasListened ?  AppColors.primary : .darkGray)
         
         titleNode = ASTextNode(track.title, textStyle: .body)
         titleNode.maximumNumberOfLines = 0
@@ -70,8 +74,8 @@ public class TrackStatusCellNode : ASCellNode {
         automaticallyManagesSubnodes = true
         
         DispatchQueue.main.async {
-            self.trackQuery = MyLibrary.shared.offline.tracks.filter("track_uuid == %@", self.track.uuid.uuidString)
-            self.trackQuery.observeWithValue { [weak self] trackResults, changes in
+            self.offlineTrackQuery = MyLibrary.shared.offline.tracks.filter("track_uuid == %@", self.track.uuid.uuidString)
+            self.offlineTrackQuery.observeWithValue { [weak self] trackResults, changes in
                 guard let s = self else { return }
                 
                 if let track = trackResults.first, track.state != .unknown, track.state != .deleting {
@@ -103,6 +107,17 @@ public class TrackStatusCellNode : ASCellNode {
                     s.setNeedsLayout()
                 }
             }.dispose(to: &self.disposal)
+            
+            
+            self.listenedTrackQuery = MyLibrary.shared.recent.tracks.filter("track_uuid == %@", self.track.uuid.uuidString)
+            self.listenedTrackQuery.observeWithValue { [weak self] trackResults, changes in
+                guard let s = self,
+                      let track = trackResults.first
+                    else { return }
+                
+                s.hasListened = track.past_halfway
+                
+            }.dispose(to: &self.disposal)
         }
         
         PlaybackController.sharedInstance.observeCurrentTrack.observe { [weak self] (current, previous) in
@@ -132,7 +147,7 @@ public class TrackStatusCellNode : ASCellNode {
     }
     
     public let nowPlayingNode: ASDisplayNode
-    public let trackNumberNode: ASTextNode
+    public var trackNumberNode: ASTextNode!
     public let titleNode: ASTextNode
     public let artistInfoNode: ASTextNode?
     public let durationNode: ASTextNode?
@@ -145,6 +160,12 @@ public class TrackStatusCellNode : ASCellNode {
     var downloadState : Track.DownloadState = .none {
         didSet {
             downloadProgressNode.state = downloadState
+        }
+    }
+    var hasListened : Bool = false {
+        didSet {
+            trackNumberNode = ASTextNode(String(explicitTrackNumber ?? track.track_position), textStyle: .caption1, color: hasListened ? AppColors.primary : .darkGray)
+            self.setNeedsDisplay()
         }
     }
 

--- a/Shared/Offline/OfflineSourceMetadata.swift
+++ b/Shared/Offline/OfflineSourceMetadata.swift
@@ -284,6 +284,7 @@ public class RecentlyPlayedTrack: RelistenRealmObject, HasTrackSourceAndShow {
     @objc public dynamic var source_uuid: String = "BAD_VALUE"
     @objc public dynamic var track_uuid: String = "BAD_VALUE"
     @objc public dynamic var updated_at: Date = Date()
+    @objc public dynamic var past_halfway: Bool = false
     
     public init(uuid: String? = nil, artist_uuid: String, show_uuid: String, source_uuid: String, track_uuid: String) {
         self.artist_uuid = artist_uuid


### PR DESCRIPTION
Record listen history the instant a track is played. Tracks that have crossed the halfway mark are considered listened to and their number appears in the primary app color.

![simulator screen shot - simulator x - 2018-09-17 at 22 28 56](https://user-images.githubusercontent.com/4943/45666110-15b24e80-bac9-11e8-914b-85f871837d05.png)
