### PR TITLE
Set default line width to 0 for download button

### DIFF
--- a/Shared/DisplayNodes/DownloadProgressNode.swift
+++ b/Shared/DisplayNodes/DownloadProgressNode.swift
@@ -86,7 +86,8 @@ public class DownloadProgressNode : ASDisplayNode {
             button.downloadedButton.setImage(DownloadProgressNode.buttonImage, for: .normal)
             button.downloadedButton.setTitleColor(AppColors.primary, for: .normal)
             button.downloadedButton.setTitleColor(AppColors.highlight, for: .highlighted)
-            
+            button.downloadedButton.lineWidth = 0
+
             button.stopDownloadButton.tintColor = AppColors.primary
             button.stopDownloadButton.filledLineStyleOuter = true
             


### PR DESCRIPTION
Fix for #135.
You can see the default style in debug view hierarchy.

![screen shot 2019-03-04 at 9 53 14 am](https://user-images.githubusercontent.com/15081579/53837390-75f65900-3f60-11e9-8871-6ae94460fa10.png)
