### PR TITLE
CI Action & mod Travis build

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,37 @@
+name: iOS CI
+
+on:
+  push:
+    branches: [ master]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Build and Test default scheme using any available iPhone simulator
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Relisten
+        run: |
+          git clone --quiet https://github.com/alecgorge/gapless-audio-bass-ios.git ../BASSGaplessAudioPlayer
+          git clone --quiet https://github.com/alecgorge/AGAudioPlayer.git ../AGAudioPlayer
+          pod update RealmSwift
+          ./setup.sh
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
+      - name: Build
+        env:
+          scheme: ${{ 'default' }}
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          device=`instruments -s -devices | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: swift
 xcode_workspace: Relisten.xcworkspace
 xcode_scheme: Relisten
 os: osx
-osx_image: xcode12.2
-xcode_scheme: Relisten
-install:
+osx_image: xcode12.1
+xcode_destination: platform=iOS Simulator,name=iPhone 12 Pro Max
+before_script:
     - ./setup.sh
 script:
     - ./xcodebuild.sh


### PR DESCRIPTION
#### PR Changelog
##### 1) Adds:  GitHub Actions CI .yml 
- Five minutes faster without tuning _(11:16 min.)_
- Allows future sunsetting of Travis CI
##### 2) Changes: Travis
- target a non-beta Xcode release 
- remove the redundant scheme from the file
